### PR TITLE
Fixed register captcha as location was incorrect

### DIFF
--- a/src/Plugin/Registration.php
+++ b/src/Plugin/Registration.php
@@ -9,8 +9,8 @@ use WP_Error;
 class Registration {
 
     public function setup() {
-        add_action( 'login_enqueue_scripts', [ AdCaptcha::class, 'enqueue_scripts' ] );
-        add_action( 'registration_errors', [ AdCaptcha::class, 'captcha_trigger' ] );
+        add_action( 'register_form', [ AdCaptcha::class, 'enqueue_scripts' ] );
+        add_action( 'register_form', [ AdCaptcha::class, 'captcha_trigger' ] );
         add_action( 'registration_errors', [ $this, 'verify' ], 10, 1 );
     }
 


### PR DESCRIPTION

<img width="543" alt="Screenshot 2024-01-23 at 11 28 16" src="https://github.com/adcaptcha-org/adCaptcha-Wordpress-plugin/assets/55638738/73fc536b-ff81-43e7-a308-12c2fadc676c">
