### PR TITLE
Update Settings.php

### DIFF
--- a/src/Settings/Settings.php
+++ b/src/Settings/Settings.php
@@ -68,7 +68,7 @@ class Settings {
     }
 
     public function change_admin_footer_text() {
-        $current_year = date('Y');
+        $current_year = gmdate('Y');
         return '© ' . $current_year . ' adCAPTCHA. All rights reserved.';
     }
 


### PR DESCRIPTION
WordPress.DateTime.RestrictedFunctions.date_date

Line 71 of file adCAPTCHA-wordpress-plugin-develop/src/Settings/Settings.php. date() is affected by runtime timezone changes which can cause date/time to be incorrectly displayed. Use gmdate() instead.

$current_year = date('Y');